### PR TITLE
fix no pointer init value

### DIFF
--- a/Adafruit_PCF8574.h
+++ b/Adafruit_PCF8574.h
@@ -41,7 +41,7 @@ public:
 private:
   uint8_t _readbuf = 0, _writebuf = 0;
 
-  Adafruit_I2CDevice *i2c_dev;
+  Adafruit_I2CDevice *i2c_dev = nullptr;
 };
 
 #endif

--- a/Adafruit_PCF8575.h
+++ b/Adafruit_PCF8575.h
@@ -41,7 +41,7 @@ public:
 private:
   uint16_t _readbuf = 0, _writebuf = 0;
 
-  Adafruit_I2CDevice *i2c_dev;
+  Adafruit_I2CDevice *i2c_dev = nullptr;
 };
 
 #endif


### PR DESCRIPTION
So, silly me: I have been banging my head against a wall trying to figure out why I couldn't create an array of `Adafruit_PCF8574` classes.  Finally broke out the debugger and realized that for some reason, my Arduino board would create blank classes when initializing the array of `Adafruit_PCF8574` objects as such:
```cpp
static Adafruit_PCF8574 pcfList[3];
```
But then if I tried to create a list like so, it would fail into the `dummy_handler()` from the `delete (i2c_dev);` from the `begin()` function.
```cpp
static Adafruit_PCF8574* pcfList;

// ...

pcfList = new Adafruit_PCF8574[pcfAddrLen];

Adafruit_PCF8574 pcf;
for (pcfListLen = 0; pcfListLen < pcfAddrLen; pcfListLen++) {

    // Create new Adafruit_PCF8574 object:
    pcf = Adafruit_PCF8574();

    // Attempt to begin communication:
    if (!pcf.begin(pcfAddr[pcfListLen])) {
        SerialUSB.print("Couldn't find PCF8574 at address 0x");
        SerialUSB.println(pcfAddr[pcfListLen]);
        while (1) {}
    }

    // Finally, save object to array list:
    pcfList[pcfListLen] = pcf;
}
```

Hopefully this is an easy enough fix to merge in.

> - **Describe the scope of your change--i.e. what the change does and what parts
>   of the code were modified.**  This will help us understand any risks of integrating
>   the code.

Just initialized the pointers in the class to be `nullptr` so that it doesn't pick up garbage from memory.

> - **Describe any known limitations with your change.**  For example if the change
>   doesn't apply to a supported platform of the library please mention it.

This does not have limitations (unless `nullptr` is not defined).

> - **Please run any tests or examples that can exercise your modified code.**  We
>   strive to not break users of the code and running tests/examples helps with this
>   process.

Passed.
