### PR TITLE
Update wait-for-serial in examples

### DIFF
--- a/examples/pcf8574_blink8leds/pcf8574_blink8leds.ino
+++ b/examples/pcf8574_blink8leds/pcf8574_blink8leds.ino
@@ -9,8 +9,7 @@ Adafruit_PCF8574 pcf;
 
 void setup() {
   Serial.begin(115200);
-  // while (!Serial) { delay(10); }
-
+  while (!Serial) { delay(10); }
   Serial.println("Adafruit PCF8574 LED blink test");
 
   if (!pcf.begin(0x20, &Wire)) {

--- a/examples/pcf8574_blinkled/pcf8574_blinkled.ino
+++ b/examples/pcf8574_blinkled/pcf8574_blinkled.ino
@@ -9,8 +9,7 @@ Adafruit_PCF8574 pcf;
 
 void setup() {
   Serial.begin(115200);
-  // while (!Serial) { delay(10); }
-
+  while (!Serial) { delay(10); }
   Serial.println("Adafruit PCF8574 LED blink test");
 
   if (!pcf.begin(0x20, &Wire)) {

--- a/examples/pcf8574_buttonledirq/pcf8574_buttonledirq.ino
+++ b/examples/pcf8574_buttonledirq/pcf8574_buttonledirq.ino
@@ -15,8 +15,7 @@ Adafruit_PCF8574 pcf;
 
 void setup() {
   Serial.begin(115200);
-  // while (!Serial) { delay(10); }
-
+  while (!Serial) { delay(10); }
   Serial.println("Adafruit PCF8574 button/led IRQ test");
 
   if (!pcf.begin(0x20, &Wire)) {

--- a/examples/pcf8574_read8buttons/pcf8574_read8buttons.ino
+++ b/examples/pcf8574_read8buttons/pcf8574_read8buttons.ino
@@ -9,8 +9,7 @@ Adafruit_PCF8574 pcf;
 
 void setup() {
   Serial.begin(115200);
-  // while (!Serial) { delay(10); }
-
+  while (!Serial) { delay(10); }
   Serial.println("Adafruit PCF8574 button read test");
 
   if (!pcf.begin(0x20, &Wire)) {

--- a/examples/pcf8575_blink16leds/pcf8575_blink16leds.ino
+++ b/examples/pcf8575_blink16leds/pcf8575_blink16leds.ino
@@ -9,8 +9,7 @@ Adafruit_PCF8575 pcf;
 
 void setup() {
   Serial.begin(115200);
-  // while (!Serial) { delay(10); }
-
+  while (!Serial) { delay(10); }
   Serial.println("Adafruit PCF8575 LED blink test");
 
   if (!pcf.begin(0x20, &Wire)) {

--- a/examples/pcf8575_blinkled/pcf8575_blinkled.ino
+++ b/examples/pcf8575_blinkled/pcf8575_blinkled.ino
@@ -9,8 +9,7 @@ Adafruit_PCF8575 pcf;
 
 void setup() {
   Serial.begin(115200);
-  // while (!Serial) { delay(10); }
-
+  while (!Serial) { delay(10); }
   Serial.println("Adafruit PCF8575 LED blink test");
 
   if (!pcf.begin(0x20, &Wire)) {

--- a/examples/pcf8575_buttonledirq/pcf8575_buttonledirq.ino
+++ b/examples/pcf8575_buttonledirq/pcf8575_buttonledirq.ino
@@ -15,8 +15,7 @@ Adafruit_PCF8575 pcf;
 
 void setup() {
   Serial.begin(115200);
-  // while (!Serial) { delay(10); }
-
+  while (!Serial) { delay(10); }
   Serial.println("Adafruit PCF8575 button/led IRQ test");
 
   if (!pcf.begin(0x20, &Wire)) {

--- a/examples/pcf8575_read16buttons/pcf8575_read16buttons.ino
+++ b/examples/pcf8575_read16buttons/pcf8575_read16buttons.ino
@@ -9,8 +9,7 @@ Adafruit_PCF8575 pcf;
 
 void setup() {
   Serial.begin(115200);
-  // while (!Serial) { delay(10); }
-
+  while (!Serial) { delay(10); }
   Serial.println("Adafruit PCF8575 button read test");
 
   if (!pcf.begin(0x20, &Wire)) {


### PR DESCRIPTION
Fix for #9.

**Two changes**: Rearranges code lines **and** comments out the wait for serial.

If there was a reason for the waits to be enabled by default, can undo comments.