### PR TITLE
CI Tweak

### DIFF
--- a/.github/workflows/githubci.yml
+++ b/.github/workflows/githubci.yml
@@ -5,7 +5,7 @@ on: [pull_request, push, repository_dispatch]
 jobs:
   build:
     runs-on: ubuntu-latest
-    
+
     steps:
     - uses: actions/setup-python@v4
       with:
@@ -19,14 +19,14 @@ jobs:
     - name: pre-install
       run: bash ci/actions_install.sh
 
-    - name: test platforms
-      run: python3 ci/build_platform.py main_platforms
-
     - name: clang
-      run: python3 ci/run-clang-format.py -e "ci/*" -e "bin/*" -r . 
+      run: python3 ci/run-clang-format.py -e "ci/*" -e "bin/*" -r .
 
     - name: doxygen
       env:
         GH_REPO_TOKEN: ${{ secrets.GH_REPO_TOKEN }}
         PRETTYNAME : "Adafruit PCF8574 Arduino Library"
       run: bash ci/doxy_gen_and_deploy.sh
+
+    - name: test platforms
+      run: python3 ci/build_platform.py main_platforms


### PR DESCRIPTION
Simple tweak to the CI. Moves time consuming build step (`test platforms`) to last, giving quick and simple clang and docs checks a chance to fail first.

![image](https://github.com/user-attachments/assets/c84a9d35-b0c2-4d0a-a84c-40493c3f56bd)
